### PR TITLE
Made SLA example copy-paste compatible

### DIFF
--- a/content/documentation/using vamp/sla.md
+++ b/content/documentation/using vamp/sla.md
@@ -48,16 +48,16 @@ clusters:
 
   sava:                        # the sava cluster
     services:
-    - breed:
+      breed:
         name: monarch
         deployable: vamp/monarch
         ports:
           webport: 80
 
-    scale:
-      cpu: 1
-      memory: 1024MB
-      instances: 2
+      scale:
+        cpu: 1
+        memory: 1024MB
+        instances: 2
 
     sla:                        # SLA applies to the first service in the sava cluster (monarch)
       # Type of SLA.


### PR DESCRIPTION
Fixed SLA section to work with copy paste.

@gggina following up on #51, the current SLA example code doesn't work when copy pasting, I tried to fix it. If its not correct I apologise in advance.

Recorded my experiences: https://www.youtube.com/watch?v=JxI4MUg8c5M 
