### PR TITLE
Fixes #139

### DIFF
--- a/static/res/v0.9.3/vga.yml
+++ b/static/res/v0.9.3/vga.yml
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       labels:
-        vamp: vamp-gateway-agent
+        io.vamp: vamp-gateway-agent
     spec:
       containers:
       - name: vamp-gateway-agent
@@ -36,10 +36,10 @@ kind: Service
 metadata:
   name: vamp-gateway-agent
   labels:
-    vamp: daemon
+    io.vamp: daemon
 spec:
   selector:
-    vamp: vamp-gateway-agent
+    io.vamp: vamp-gateway-agent
   type: LoadBalancer
   ports:
   - name: p80


### PR DESCRIPTION
This fixes the labels on the vamp-gateway-agent, so newly created kubernetes services (aka vamp gateways) will have proper endpoints (matching Selectors and labels on the VGAs).